### PR TITLE
feat: add initial LLM bot integration

### DIFF
--- a/trunk/game/package.json
+++ b/trunk/game/package.json
@@ -6,14 +6,15 @@
   "engines": {
     "node": "0.8.15"
   },
-  "dependencies": {
-    "entities": "0.3.0",
-    "redis": "0.7.1",
-    "rpsc":"0.0.2",
-    "bcrypt-nodejs": "0.0.3",
-    "express": "3.1.0",
-    "sockjs": "0.3.7"
-  },
+    "dependencies": {
+        "entities": "0.3.0",
+        "redis": "0.7.1",
+        "rpsc":"0.0.2",
+        "bcrypt-nodejs": "0.0.3",
+        "express": "3.1.0",
+        "sockjs": "0.3.7",
+        "node-fetch": "2.6.1"
+    },
   "optionalDependencies": {
     "hiredis": "0.1.14"
   }

--- a/trunk/game/server/llm.bot.js
+++ b/trunk/game/server/llm.bot.js
@@ -1,0 +1,39 @@
+const fetch = require('node-fetch');
+
+async function queryLLM(prompt){
+    const endpoint = process.env.LLM_BOT_ENDPOINT;
+    if(!endpoint){
+        return '';
+    }
+    try{
+        const res = await fetch(endpoint, {
+            method: 'POST',
+            headers: {'Content-Type':'application/json'},
+            body: JSON.stringify({prompt})
+        });
+        const data = await res.json();
+        return data.reply || data.text || '';
+    }catch(e){
+        return '';
+    }
+}
+
+module.exports = {
+    decideNightAction: async function(gameState, actions){
+        const prompt = `phase ${gameState.phase} actions ${JSON.stringify(actions)}`;
+        const resp = await queryLLM(prompt);
+        const idx = parseInt(resp);
+        return { action: actions[idx] || actions[0], target1: -1, target2: -1 };
+    },
+    generateChat: async function(gameState, history){
+        const prompt = `chat phase ${gameState.phase}`;
+        const resp = await queryLLM(prompt);
+        return resp || '';
+    },
+    decideVote: async function(gameState, candidates){
+        const prompt = `vote phase ${gameState.phase} candidates ${candidates.join(',')}`;
+        const resp = await queryLLM(prompt);
+        const choice = parseInt(resp);
+        return candidates.includes(choice) ? choice : candidates[0];
+    }
+};

--- a/trunk/game/server/mafia.gameclient.js
+++ b/trunk/game/server/mafia.gameclient.js
@@ -1260,17 +1260,19 @@ var GameClient = function(){
 												'uniqueid': -1,
 												'playername': 'Player '+new_player_id,
 												'connected':0,
-												'role': -1,
-												'startingrole': -1,
-												'playerstate': -1,
-												'actionsremaining': -1
-											})
-										.publish('maf.serverupdates.1', JSON.stringify({
-											'subType':'listing_update',
-											'message':[{'updateType':'UPDATE', 'gameid':gameid, 'playercount':newPlayerCount}]
-										}))
-										.exec(function(){
-											db.multi()
+                                                                                                'role': -1,
+                                                                                                'startingrole': -1,
+                                                                                                'playerstate': -1,
+                                                                                                'actionsremaining': -1,
+                                                                                                'is_bot':1
+                                                                                        })
+                                                                                .sadd('maf:games:'+gameid+':botlist', new_player_id)
+                                                                                .publish('maf.serverupdates.1', JSON.stringify({
+                                                                                        'subType':'listing_update',
+                                                                                        'message':[{'updateType':'UPDATE', 'gameid':gameid, 'playercount':newPlayerCount}]
+                                                                                }))
+                                                                                .exec(function(){
+                                                                                        db.multi()
 												.publish('maf.games.'+gameid, JSON.stringify({
 													'subType':'lobby',
 													'message':{player_updates:[{updateType:'ADD', userid:userid, username: username, ishost:0, isready:1}]}

--- a/trunk/game/server/mafia.gameserver.js
+++ b/trunk/game/server/mafia.gameserver.js
@@ -1,8 +1,9 @@
 var GameServer = function(){
-	var 
-		_this = this,
-		maf = false,
-		db = false;
+        var
+                _this = this,
+                maf = false,
+                db = false,
+                llmBot = require('./llm.bot');
 	
 	// Private methods
 	var constructor = function(tmaf){
@@ -1075,16 +1076,16 @@ var GameServer = function(){
             ensureEntered(tpm.receiver, 'message_updates', tpm);
         });
 
-	    getNextPhaseActions(gameid, message['day'], message['dayphase'], function (pactions)
-	    {
+            getNextPhaseActions(gameid, message['day'], message['dayphase'], function (pactions)
+            {
 
-	        Object.keys(pactions).forEach(function (uid)
-	        {
-	            ensureEntered(uid, 'action_enable_updates', pactions[uid]);
+                Object.keys(pactions).forEach(function (uid)
+                {
+                    ensureEntered(uid, 'action_enable_updates', pactions[uid]);
             });
-
-	        getPrivateGroupChats(gameid, message['day'], message['dayphase'], function (pgchats)
-	        {
+                runLLMBots(gameid, message['day'], message['dayphase'], pactions);
+                getPrivateGroupChats(gameid, message['day'], message['dayphase'], function (pgchats)
+                {
 
 	            Object.keys(pgchats).forEach(function (uid)
 	            {
@@ -1353,7 +1354,75 @@ var GameServer = function(){
                 });
             });
     }
-	var buildGameLogicObj = function(gameid, callback){
+    var runLLMBots = function(gameid, day, phase, pactions){
+        db.smembers('maf:games:'+gameid+':botlist', function(err, botPlayerIds){
+            if(err || !botPlayerIds || botPlayerIds.length===0) return;
+            db.smembers('maf:games:'+gameid+':playerlist', function(err, allPlayerIds){
+                var multi = db.multi();
+                allPlayerIds.forEach(function(plid){
+                    multi.hmget('maf:games:'+gameid+':players:'+plid, ['uniqueid','playerstate']);
+                });
+                multi.exec(function(err, info){
+                    if(err) return;
+                    var aliveUniqueIds = [];
+                    var bots = [];
+                    info.forEach(function(pl, i){
+                        var uid = parseInt(pl[0]);
+                        var alive = parseInt(pl[1])===1;
+                        if(alive) aliveUniqueIds.push(uid);
+                        if(botPlayerIds.indexOf(allPlayerIds[i])!==-1){
+                            bots.push({playerid: allPlayerIds[i], uniqueid: uid, alive: alive});
+                        }
+                    });
+                    bots.forEach(function(b){
+                        if(!b.alive) return;
+                        if(phase==0){
+                            var actions = pactions[b.uniqueid] || [];
+                            if(actions.length===0) return;
+                            llmBot.decideNightAction({day:day, phase:phase}, actions).then(function(choice){
+                                var act = choice.action || actions[0];
+                                var t1 = typeof choice.target1==='number'?choice.target1:-1;
+                                var t2 = typeof choice.target2==='number'?choice.target2:-1;
+                                db.multi()
+                                    .hmset('maf:games:'+gameid+':actions:'+day+':'+phase+':'+b.uniqueid, {
+                                        'actiontype':act.actionid,
+                                        'initiator_uniqueid':b.uniqueid,
+                                        'target1':t1,
+                                        'target2':t2,
+                                        'day':day,
+                                        'dayphase':phase
+                                    })
+                                    .sadd('maf:games:'+gameid+':actions:'+day+':'+phase, 'actions:'+day+':'+phase+':'+b.uniqueid)
+                                    .exec(function(){
+                                        db.publish('maf.games.'+gameid, JSON.stringify({'subType':'game_actioncount_change','message':{'uniqueid':b.uniqueid,'actiontype':act.actionid,'target1':t1,'target2':t2}}));
+                                    });
+                            });
+                        } else if(phase==2){
+                            llmBot.generateChat({day:day, phase:phase}, []).then(function(msg){
+                                if(!msg) return;
+                                db.publish('maf.games.'+gameid, JSON.stringify({'subType':'game_chat','message':{'chat_updates':[{'origin':b.uniqueid,'destination':'g-1','message':msg}]}}));
+                            });
+                        } else if(phase==3){
+                            var candidates = aliveUniqueIds.filter(function(uid){return uid!==b.uniqueid;});
+                            if(candidates.length===0) return;
+                            llmBot.decideVote({day:day, phase:phase}, candidates).then(function(victim){
+                                victim = victim || candidates[0];
+                                db.multi()
+                                    .hget('maf:games:'+gameid+':votes:'+day+':3:'+b.uniqueid, 'receiver_uniqueid')
+                                    .hmset('maf:games:'+gameid+':votes:'+day+':3:'+b.uniqueid, {'receiver_uniqueid':victim,'vote_value':1})
+                                    .sadd('maf:games:'+gameid+':votes:'+day+':3', 'votes:'+day+':3:'+b.uniqueid)
+                                    .exec(function(err, repliesb){
+                                        var oldid = repliesb && repliesb[0]!=null?parseInt(repliesb[0]):false;
+                                        db.publish('maf.games.'+gameid, JSON.stringify({'subType':'game_vote','message':{'oldvictimid':oldid,'victimid':victim,'voteval':1,'voterid':b.uniqueid}}));
+                                    });
+                            });
+                        }
+                    });
+                });
+            });
+        });
+    }
+        var buildGameLogicObj = function(gameid, callback){
 		var stateObj = {gameid:gameid};
 		db.hmget('maf:games:'+gameid, ['playercount', 'day', 'dayphase'], function(err, gamestate){
 			stateObj.playerCount = +gamestate[0];


### PR DESCRIPTION
## Summary
- mark joined bots and track bot players
- wire LLM-driven logic for actions, chat, and voting
- add helper to call external LLM API
概要
bot参加処理にis_botフラグとbotプレイヤーリスト登録を追加し、ボットを識別可能にしました

フェーズ遷移時にrunLLMBotsを呼び出してボットの行動・発言・投票を自動実行するように変更しました

外部LLMを呼び出すヘルパーllm.bot.jsを新設し、行動・チャット・投票の各判断を委譲できるようにしました

LLM連携用にnode-fetch依存を追加しました
## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fd3aeac88833298c9432e589c77f5