### PR TITLE
Show role display names and enlarge selection UI

### DIFF
--- a/trunk/game/client/libs/jq.minputs/jq.minputs.style.css
+++ b/trunk/game/client/libs/jq.minputs/jq.minputs.style.css
@@ -660,14 +660,14 @@
 	{
 		position: absolute;
 		top: 0;
-		left: -120px;
-		right: -50px;
-		height: 200px;
-		background: white;
-		border: 1px solid #919191;
-		border-radius: 2px;
-		box-shadow: 0 0 5px 0 #CCC;
-		overflow: hidden;
+        left: -200px;
+        right: -200px;
+        height: 350px;
+        background: white;
+        border: 1px solid #919191;
+        border-radius: 2px;
+        box-shadow: 0 0 5px 0 #CCC;
+        overflow: hidden;
 		-webkit-touch-callout: none;-webkit-user-select: none;-khtml-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;
 	}
 		.mafinputgroup .list_inner_col

--- a/trunk/game/client/libs/jq.minputs/jq.minputs.style.css
+++ b/trunk/game/client/libs/jq.minputs/jq.minputs.style.css
@@ -662,7 +662,7 @@
 		top: 0;
         left: -200px;
         right: -200px;
-        height: 350px;
+        height: 550px;
         background: white;
         border: 1px solid #919191;
         border-radius: 2px;

--- a/trunk/game/client/skins/menu/mafia/mafia.js
+++ b/trunk/game/client/skins/menu/mafia/mafia.js
@@ -542,7 +542,26 @@ new function(){
 					};
 					if(typeof gs.value != 'undefined')temp['value'] = gs.value;
 					if(typeof gs.values != 'undefined')temp['values'] = gs.values;
-					if(typeof gs.options != 'undefined')temp['options'] = gs.options;
+					//if(typeof gs.options != 'undefined')temp['options'] = gs.options;
+					if(typeof gs.options != 'undefined'){  
+						if(gs.id == 'ssetting_roleselection'){  
+							// 役割選択の場合は表示名に変換  
+							temp['options'] = gs.options.map(function(opt){  
+								if(opt.value.indexOf('role_') != -1){  
+									var roleid = +opt.value.replace('role_', '');  
+									return {'display': lang('roles.'+roleid+'.displayname'), 'value': opt.value};  
+								} else if(opt.value.indexOf('rand_') != -1){  
+									var roleid = +opt.value.replace('rand_', '');  
+									return {'display': lang('randomroles.'+roleid+'.displayname'), 'value': opt.value};  
+								}  
+								return opt;  
+							});  
+						} else {  
+							temp['options'] = gs.options;  
+						}  
+					}
+
+
 					if(typeof gs.schema != 'undefined')temp['schema'] = gs.schema;
 					settingsStructure.groups[0].inputs.push( temp );
 				});

--- a/trunk/game/server/mafia.setup.js
+++ b/trunk/game/server/mafia.setup.js
@@ -81,9 +81,9 @@ var Setup = new function(){
             .map(function(ntheme){return {'display':ntheme.displayname,'value':ntheme.id};});
         roleSelectionOptions =  Array.prototype.concat.apply([], [
             this.globals.gameConfig.randomroles
-                .map(function(role){return {'display':role.displayid,'value':'rand_'+role.randomroleid};}),
+                .map(function(role){return {'display':role.displayname,'value':'rand_'+role.randomroleid};}),
             this.globals.gameConfig.roles
-                .map(function(role){return {'display':role.displayid,'value':'role_'+role.roleid};})
+                .map(function(role){return {'display':role.displayname,'value':'role_'+role.roleid};})
         ]);
             
 		this.constants.MAFIA_PHASE_TIMES_DEFAULTS.forEach(function(phasetime, i){phaseTimeValues[i] = phasetime;});		

--- a/trunk/game/server/mafia.setup.js
+++ b/trunk/game/server/mafia.setup.js
@@ -81,9 +81,9 @@ var Setup = new function(){
             .map(function(ntheme){return {'display':ntheme.displayname,'value':ntheme.id};});
         roleSelectionOptions =  Array.prototype.concat.apply([], [
             this.globals.gameConfig.randomroles
-                .map(function(role){return {'display':role.displayname,'value':'rand_'+role.randomroleid};}),
+                .map(function(role){return {'display':role.displayid,'value':'rand_'+role.randomroleid};}),
             this.globals.gameConfig.roles
-                .map(function(role){return {'display':role.displayname,'value':'role_'+role.roleid};})
+                .map(function(role){return {'display':role.displayid,'value':'role_'+role.roleid};})
         ]);
             
 		this.constants.MAFIA_PHASE_TIMES_DEFAULTS.forEach(function(phasetime, i){phaseTimeValues[i] = phasetime;});		


### PR DESCRIPTION
## Summary
- Use localized display names for role selection options
- Expand role add/remove list dimensions for better visibility
変更内容
ゲーム設定の役割選択に表示名を使用し、各役割が言語リソースの表示名で示されるように修正

役割の追加・削除選択画面を広げ、操作領域の幅と高さを拡張
## Testing
- `npm test` *(fails: Missing script: "test")*
- `node ../tests/rpss/test.mafia.rpss.js` *(fails: Cannot find module 'redis')*

------
https://chatgpt.com/codex/tasks/task_e_689fd675f67083328a6c201700dd3a07